### PR TITLE
Add some v4l2 controls as dynamic reconfigure parameters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(realsense_camera)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  dynamic_reconfigure
   roscpp
   roslib
   std_msgs
@@ -25,6 +26,9 @@ find_package(PCL 1.7 REQUIRED COMPONENTS
     io
 )
 
+generate_dynamic_reconfigure_options(
+  config/RealsenseCamera.cfg
+)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
@@ -173,6 +177,7 @@ add_executable(realsense_camera_config_node
 
 add_dependencies(realsense_camera_node realsense_camera_generate_messages_cpp)
 add_dependencies(realsense_camera_config_node realsense_camera_generate_messages_cpp)
+add_dependencies(realsense_camera_node ${PROJECT_NAME}_gencfg)
 
 
 ## Specify libraries to link a library or executable target against

--- a/config/RealsenseCamera.cfg
+++ b/config/RealsenseCamera.cfg
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+PACKAGE = "realsense_camera"
+NODE = "realsense_camera_node"
+
+gen = ParameterGenerator()
+#       Name       Type      Level Description     Default Min   Max
+gen.add("laser_power", int_t, 0, "Laser Power", 16, 1, 16)
+
+accuracy_enum = gen.enum([gen.const("Finest", int_t, 1, "11 patterns, 50fps"),
+                          gen.const("Median", int_t, 2, "10 patterns, 55fps"),
+                          gen.const("Coarse", int_t, 3, "9 patterns, 60fps")],
+                          "An enum to set accuracy")
+gen.add("accuracy", int_t, 0, "Accuracy - The projected pattern", 2, 1, 3, edit_method=accuracy_enum)
+
+gen.add("motion_range_trade_off", int_t, 0, "Motion Range Trade Off - Short exposure and short range (0) to long exposure and long range (100)", 0, 0, 100)
+
+filter_enum = gen.enum([gen.const("skeleton", int_t, 0, "Reports the depth data for high fidelity (high confidence) pixels only, and all other pixels as invalid."),
+                        gen.const("raw", int_t, 1, "Raw depth image without any post-processing filters."),
+                        gen.const("raw_and_gradients_filter", int_t, 2, "Raw depth image  with the gradient filter applied."),
+                        gen.const("very_close_range", int_t, 3, "Very low smoothing effect with high sharpness, accuracy levels, and low noise artifacts. Good for any distances of up to 350mm."),
+                        gen.const("close_range", int_t, 4, "Low smoothing effect with high sharpness and accuracy levels. The noise artifacts are optimized for distances between 350mm to 550mm."),
+                        gen.const("mid_range", int_t, 5, "Moderate smoothing effect optimized for distances between 550mm to 850mm to balance between good sharpness level, high accuracy and moderate noise artifacts."),
+                        gen.const("far_range", int_t, 6, "High smoothing effect for distances between 850mm to 1000mm bringing good accuracy with moderate sharpness level."),
+                        gen.const("very_far_range", int_t, 7, "Very high smoothing effect to bring moderate accuracy level for distances above 1000mm. Use together with the MotionRangeTradeOff property to increase the depth range.")],
+                        "An enum to set filter options")
+gen.add("filter_option", int_t, 0, "The smoothing aggressiveness parameter", 5, 0, 7, edit_method=filter_enum)
+
+gen.add("confidence_threshold", int_t, 0, "The confidence threshold that is used to floor the depth map values.", 6, 0, 15)
+
+exit(gen.generate(PACKAGE, NODE, "RealsenseCamera"))

--- a/package.xml
+++ b/package.xml
@@ -47,8 +47,10 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/capturer_mmap.h
+++ b/src/capturer_mmap.h
@@ -13,6 +13,8 @@
 #include <linux/videodev2.h>
 #include <limits.h>
 
+#include <string>
+
 #define RESULT_SUCCESS 0
 #define RESULT_FAILURE 1
 
@@ -47,4 +49,6 @@ int capturer_mmap_get_frame(PVideoStream p_video_stream);
 
 void capturer_mmap_exit(PVideoStream p_video_stream);
 
+void capturer_mmap_init_v4l2_controls();
 
+int capturer_mmap_set_control(PVideoStream p_video_stream, const std::string &control, int value);

--- a/src/realsense_camera.cpp
+++ b/src/realsense_camera.cpp
@@ -26,6 +26,8 @@
 #include "realsense_camera/realsenseConfig.h"
 #include "realsense_camera/get_rgb_uv.h"
 
+#include <dynamic_reconfigure/server.h>
+#include <realsense_camera/RealsenseCameraConfig.h>
 
 
 
@@ -585,6 +587,30 @@ realsenseConfigCallback(const realsense_camera::realsenseConfig::ConstPtr &confi
 	}
 }
 
+void
+dynamicReconfigCallback(realsense_camera::RealsenseCameraConfig &config, uint32_t level)
+{
+    if (capturer_mmap_set_control(&depth_stream, "Laser Power", config.laser_power))
+    {
+        printf("Could not set Laser Power to %i", config.laser_power);
+    }
+    if (capturer_mmap_set_control(&depth_stream, "Accuracy", config.accuracy))
+    {
+        printf("Could not set Accuracy to %i", config.accuracy);
+    }
+    if (capturer_mmap_set_control(&depth_stream, "Motion Range Trade Off", config.motion_range_trade_off))
+    {
+        printf("Could not set Motion Range Trade Off to %i", config.motion_range_trade_off);
+    }
+    if (capturer_mmap_set_control(&depth_stream, "Filter Option", config.filter_option))
+    {
+        printf("Could not set Filter Option to %i", config.filter_option);
+    }
+    if (capturer_mmap_set_control(&depth_stream, "Confidence Threshold", config.confidence_threshold))
+    {
+        printf("Could not set Confidence Threshold to %i", config.confidence_threshold);
+    }
+}
 
 bool getRGBUV(realsense_camera::get_rgb_uv::Request  &req,
                 realsense_camera::get_rgb_uv::Response &res)
@@ -809,6 +835,9 @@ int main(int argc, char* argv[])
 
     getRGBUVService = n.advertiseService("get_rgb_uv", getRGBUV);
 
+    capturer_mmap_init_v4l2_controls();
+    dynamic_reconfigure::Server<realsense_camera::RealsenseCameraConfig> dynamic_reconfigure_server;
+    dynamic_reconfigure_server.setCallback(boost::bind(&dynamicReconfigCallback, _1, _2));
 
     ros::Rate loop_rate(60);
 


### PR DESCRIPTION
I added a dynamic reconfigure server to set Laser Power, Accuracy, Motion Range Trade Off, Filter Option and Confidence Threshold on the depth stream while running the node. 
The control mappings are dependent on using these udev rules https://github.com/teknotus/depthview/tree/udev by @teknotus 
